### PR TITLE
feat(forms): show character limits and fix field edit persistence

### DIFF
--- a/app/Livewire/FormFieldManager.php
+++ b/app/Livewire/FormFieldManager.php
@@ -163,11 +163,18 @@ class FormFieldManager extends Component
             $fieldData['label'] = null;
             $fieldData['options'] = null;
             $fieldData['required'] = false;
+            $fieldData['char_limit'] = null;
         } else {
             $fieldData['label'] = $this->newField['label'];
             $fieldData['options'] = $this->newField['options'];
             $fieldData['required'] = $this->newField['required'];
             $fieldData['content'] = null;
+            // Persist char_limit only for text/textarea
+            if (in_array($this->newField['type'], ['text', 'textarea'])) {
+                $fieldData['char_limit'] = $this->newField['char_limit'] ?? null;
+            } else {
+                $fieldData['char_limit'] = null;
+            }
         }
 
         FormField::create($fieldData);
@@ -182,17 +189,22 @@ class FormFieldManager extends Component
         $this->newField['options'] = '';
         $this->newField['content'] = '';
         $this->newField['required'] = false;
+        $this->newField['char_limit'] = null;
     }
 
     private function fieldValidationRules($prefix = 'newField'): array
     {
         $rules = [
             $prefix.'.type' => 'required|in:header,description,text,textarea,select,checkbox,radio,file',
-            $prefix.'.category_id' => [
+        ];
+
+        // Only require category_id when creating a new field via the add form.
+        if ($prefix === 'newField') {
+            $rules[$prefix.'.category_id'] = [
                 'required',
                 Rule::exists('form_categories', 'id')->where('form_id', $this->form->id),
-            ],
-        ];
+            ];
+        }
 
         if (in_array($this->{$prefix}['type'], ['header', 'description'])) {
             $rules[$prefix.'.content'] = 'required|string|max:500';
@@ -338,10 +350,15 @@ class FormFieldManager extends Component
             $this->fieldBeingEdited['label'] = null;
             $this->fieldBeingEdited['options'] = null;
             $this->fieldBeingEdited['required'] = false;
+            $this->fieldBeingEdited['char_limit'] = null;
         } else {
             $this->fieldBeingEdited['content'] = null;
             if (!in_array($this->fieldBeingEdited['type'], ['select', 'checkbox', 'radio'])) {
                 $this->fieldBeingEdited['options'] = null;
+            }
+            // Ensure char_limit is only kept for text/textarea
+            if (!in_array($this->fieldBeingEdited['type'], ['text', 'textarea'])) {
+                $this->fieldBeingEdited['char_limit'] = null;
             }
         }
 

--- a/app/Livewire/SubmissionForm.php
+++ b/app/Livewire/SubmissionForm.php
@@ -728,7 +728,7 @@ class SubmissionForm extends Component
                         if (!empty($field->options)) {
                               // Split the options and validate against individual options
                             $optionsArray = array_map('trim', explode(',', $field->options));
-                            $fieldRules[] = 'in:' . implode(',', $optionsArray);
+                            $fieldValueRules[] = 'in:' . implode(',', $optionsArray);
                         }
                         break;
 
@@ -744,11 +744,11 @@ class SubmissionForm extends Component
                         // For file fields, fieldValues might contain paths (existing files) or be empty
                         // Only validate as string/path when it exists
                         if (isset($this->fieldValues[$field->id]) && is_string($this->fieldValues[$field->id])) {
-                            $fieldRules[] = 'string';
+                            $fieldValueRules[] = 'string';
                         } else {
                             // If no existing file, remove required rule as tempFiles will handle new uploads
-                            $fieldRules = array_filter($fieldRules, fn($rule) => $rule !== 'required');
-                            $fieldRules[] = 'nullable';
+                            $fieldValueRules = array_filter($fieldValueRules, fn($rule) => $rule !== 'required');
+                            $fieldValueRules[] = 'nullable';
                         }
                         
                         // Add validation rules for new file uploads
@@ -768,11 +768,11 @@ class SubmissionForm extends Component
 
                 // Add rules for field values (skip files as they're handled above)
                 if ($field->type !== 'file') {
-                    $rules["fieldValues.{$field->id}"] = $fieldRules;
+                    $rules["fieldValues.{$field->id}"] = $fieldValueRules;
                 } else {
                     // For file fields, only validate fieldValues if it contains a path
-                    if (!empty($fieldRules)) {
-                        $rules["fieldValues.{$field->id}"] = $fieldRules;
+                    if (!empty($fieldValueRules)) {
+                        $rules["fieldValues.{$field->id}"] = $fieldValueRules;
                     }
                 }
             }

--- a/resources/views/livewire/form-field-manager.blade.php
+++ b/resources/views/livewire/form-field-manager.blade.php
@@ -325,7 +325,7 @@
                             </div>
                         </div>
                         <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-                            <button type="submit"
+                            <button type="submit" wire:click.prevent="updateCategory"
                                     class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-blue-600 text-base font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm">
                                 Update
                             </button>
@@ -443,12 +443,6 @@
                                     </div>
                                 @endif
 
-                                <!-- In the Form Structure display, add this after the field type display -->
-                                @if(isset($field['char_limit']) && $field['char_limit'] && in_array($field['type'], ['text', 'textarea']))
-                                    <span class="text-gray-500 dark:text-gray-400 ml-2">
-                                    (max {{ $field['char_limit'] }} characters)
-                                    </span>
-                                @endif
                             @endif
                         </div>
                         <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">

--- a/resources/views/livewire/submission-form.blade.php
+++ b/resources/views/livewire/submission-form.blade.php
@@ -122,14 +122,16 @@
                         @if($field->type === 'text')
                             <input type="text"
                                    id="field_{{ $field->id }}"
-                                   wire:model.debounce.1000ms="fieldValues.{{ $field->id }}"
+                                   wire:model.live="fieldValues.{{ $field->id }}"
+                                   @if($field->char_limit) placeholder="Max {{ $field->char_limit }} characters" @endif
                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                                    @if($field->char_limit) maxlength="{{ $field->char_limit }}" @endif>
 
                         @elseif($field->type === 'textarea')
                             <textarea id="field_{{ $field->id }}"
-                                      wire:model.debounce.1000ms="fieldValues.{{ $field->id }}"
+                                      wire:model.live="fieldValues.{{ $field->id }}"
                                       rows="3"
+                                      @if($field->char_limit) placeholder="Max {{ $field->char_limit }} characters" @endif
                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                                       @if($field->char_limit) maxlength="{{ $field->char_limit }}" @endif></textarea>
 
@@ -233,8 +235,20 @@
                         @enderror
 
                         @if($field->char_limit)
-                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                                Characters: {{ strlen($fieldValues[$field->id] ?? '') }}/{{ $field->char_limit }}
+                            @php
+                                $used = strlen($fieldValues[$field->id] ?? '');
+                                $limit = (int) $field->char_limit;
+                                $threshold = max((int) ceil($limit * 0.9), 1); // 90% used
+                                $nearLimit = $used >= $threshold && $used < $limit;
+                            @endphp
+                            <p class="mt-1 text-sm aria-live-polite"
+                               aria-live="polite"
+                               @class([
+                                   'text-gray-500 dark:text-gray-400' => !$nearLimit && $used < $limit,
+                                   'text-amber-600 dark:text-amber-400' => $nearLimit,
+                                   'text-red-600 dark:text-red-500' => $used >= $limit,
+                               ])>
+                                {{ $used }}/{{ $limit }} characters
                             </p>
                         @endif
                     @endif


### PR DESCRIPTION
- Add live character counter and HTML5 maxlength for text/textarea on submission page
  - Switch to 0/N “characters” counter with near-limit color cues (amber at ≥90%, red at limit)
  - Update bindings to wire:model.live for instant updates
  - Remove “Max N characters” helper under labels
- Persist char_limit correctly when creating/updating fields
  - Save char_limit only for text/textarea; clear for other types
  - Reset char_limit when changing new field type
- Fix Livewire validation blocking field updates
  - Require category_id only for newField, not during edit
- Clean up edit modal UI
  - Remove stray “(max X characters)” span